### PR TITLE
prevented errors related node-gyp package and bootstrap update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ Star Admin is released under MIT license. Star Admin is a free Bootstrap 4 admin
 
 2 - After the files have been downloaded you will get a folder with all the required files
 
-3 - Open your terminal (Run as Administrator). You can install all the dependencies in the template by running the command npm install. All the required files are in the node modules. If you didn't run with admin authority, you can see errors.
+3 - Open your terminal (Run as Administrator). You can install all the dependencies in the template by running the command npm install. All the required files are in the node modules. If you didn't run with admin authorities, you can see errors.
 
 4 - Find the file named index.html, check what all components you need. Open the file in a text editor and you can start editing.
 
 5 - Now that your project has now kick-started, all you need to do now is to code, code, and code to your heart's content.
+
+__Note :__ If you use laravel-mix, please run all command with admin authorities.
 
 <h1>How to Contribute?:</h1>
 <hr>

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ Star Admin is released under MIT license. Star Admin is a free Bootstrap 4 admin
 <hr>
 
 
+0 - Install `node-gyp` package. If you dont know installation steps, please [click here](https://github.com/nodejs/node-gyp)
+
 1 - Click the Clone or Download button in GitHub and download as a ZIP file or you can enter the command git clone https://github.com/BootstrapDash/StarAdmin-Free-Bootstrap-Admin-Template.git in you terminal to get a copy of this template.
 
 2 - After the files have been downloaded you will get a folder with all the required files
 
-3 - You can install all the dependencies in the template by running the command npm install. All the required files are in the node modules.
+3 - Open your terminal (Run as Administrator). You can install all the dependencies in the template by running the command npm install. All the required files are in the node modules. If you didn't run with admin authority, you can see errors.
 
 4 - Find the file named index.html, check what all components you need. Open the file in a text editor and you can start editing.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.html",
   "dependencies": {
-    "bootstrap": "4.0.0",
+    "bootstrap": "4.1.3",
     "chart.js": "2.7.1",
     "flag-icon-css": "2.9.0",
     "font-awesome": "4.7.0",


### PR DESCRIPTION
I gave many errors when I am working integrate template to my project. I solved the problems. Errors were related incorrect installation of node-gyp.